### PR TITLE
Changed the object projection to Any instead of IUnknown among other minor changes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,3 +17,7 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+java {
+    withSourcesJar()
+}

--- a/code-generator/build.gradle.kts
+++ b/code-generator/build.gradle.kts
@@ -49,3 +49,7 @@ publishing {
         }
     }
 }
+
+java {
+    withSourcesJar()
+}

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateClass.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateClass.kt
@@ -54,7 +54,7 @@ fun generateClass(
             addSuperinterface(superinterface)
         }
 
-        addSuperinterface(IUnknown::class)
+        addSuperinterface(IInspectable::class)
         addSuperinterface(IWinRTObject::class)
 
         generateClassTypeSpec(sparseClass)

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateClass.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateClass.kt
@@ -6,20 +6,24 @@ import com.github.knk190001.winrtbinding.generator.model.ArrayType
 import com.github.knk190001.winrtbinding.generator.model.arrayType
 import com.github.knk190001.winrtbinding.generator.model.entities.*
 import com.github.knk190001.winrtbinding.runtime.JNAApiInterface
+import com.github.knk190001.winrtbinding.runtime.annotations.WinRTByReference
 import com.github.knk190001.winrtbinding.runtime.base.CompositionPointerType
 import com.github.knk190001.winrtbinding.runtime.base.IABI
 import com.github.knk190001.winrtbinding.runtime.base.IKotlinWinRTAggregate
 import com.github.knk190001.winrtbinding.runtime.com.*
 import com.github.knk190001.winrtbinding.runtime.interop.IEvent
-import com.github.knk190001.winrtbinding.runtime.interop.IUnknownByReference
+import com.github.knk190001.winrtbinding.runtime.interop.AnyByReference
+import com.github.knk190001.winrtbinding.runtime.interop.IByReference
 import com.github.knk190001.winrtbinding.runtime.interop.WinRTObjectInitializer
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.MemberName.Companion.member
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.PointerType
 import com.sun.jna.platform.win32.Guid
 import com.sun.jna.platform.win32.Guid.REFIID
+import com.sun.jna.ptr.ByReference
 import com.sun.jna.ptr.PointerByReference
 import java.lang.foreign.MemoryAddress
 import java.lang.foreign.MemoryLayout
@@ -58,7 +62,7 @@ fun generateClass(
         addSuperinterface(IWinRTObject::class)
 
         generateClassTypeSpec(sparseClass)
-        addByReferenceType(sparseClass)
+        addByReferenceType(sparseClass, "ptr")
         generateClassABI(sparseClass)
         if (sparseClass.hasStaticInterfaces) {
             generateCompanion(sparseClass, lookUp)
@@ -66,6 +70,39 @@ fun generateClass(
     }.build()
     addType(classTypeSpec)
 }.build()
+
+private fun TypeSpec.Builder.addByReferenceType(entity: INamedEntity, ptrPropertyName: String? = null) {
+    val brAnnotationSpec = AnnotationSpec.builder(WinRTByReference::class)
+        .addMember("brClass = %L.ByReference::class", entity.name)
+        .build()
+    addAnnotation(brAnnotationSpec)
+    val byReference = TypeSpec.classBuilder("ByReference").apply {
+        addSuperinterface(IByReference::class.asClassName().parameterizedBy(ClassName("", entity.name)))
+        generateByReferenceType(entity)
+    }.build()
+    addType(byReference)
+}
+
+private fun TypeSpec.Builder.generateByReferenceType(entity: INamedEntity) {
+    val className = ClassName.bestGuess("${entity.namespace}.${entity.name}")
+
+    superclass(ByReference::class)
+    val ptrSize = Native::class.member("POINTER_SIZE")
+    addSuperclassConstructorParameter("%M", ptrSize)
+
+    val getValueSpec = FunSpec.builder("getValue").apply {
+        addModifiers(KModifier.OVERRIDE)
+        addCode("return %T(ptr = pointer.getPointer(0))", className)
+    }.build()
+    addFunction(getValueSpec)
+
+    val setValueSpec = FunSpec.builder("setValue").apply {
+        addParameter("value", className)
+        addCode("pointer.setPointer(0, value.pointer)")
+    }.build()
+    addFunction(setValueSpec)
+}
+
 
 private fun TypeSpec.Builder.generateCompanion(sparseClass: SparseClass, lookUp: LookUp) {
     val interfaces = sparseClass.staticInterfaces.map(lookUp)
@@ -238,7 +275,7 @@ private fun TypeSpec.Builder.addFromNative(sparseClass: SparseClass) {
         addParameter("segment", MemoryAddress::class)
         returns(sparseClass.asTypeReference().asClassName())
         addStatement("val address = segment.toRawLongValue()", ValueLayout::class.member("ADDRESS"))
-        addStatement("return %T(%T(address))".fixSpaces(), sparseClass.asTypeReference().asClassName(), Pointer::class)
+        addStatement("return %T(ptr = %T(address))".fixSpaces(), sparseClass.asTypeReference().asClassName(), Pointer::class)
     }.build()
     addFunction(fromNative)
 }
@@ -318,13 +355,13 @@ fun TypeSpec.Builder.generateCompositionFactoryActivationFunction(
 
         returns(nullablePtr)
         val cb = CodeBlock.builder().apply {
-            addStatement("val inner = %T()", IUnknownByReference::class)
+            addStatement("val inner = %T()", AnyByReference::class)
             add("val obj = ${factoryInterface.name}_Instance.${method.name}(")
             add((userParams.map { it.name } +
-                    listOf("%T.ABI.makeIUnknown(aggregatingClass?.initAggregate())", "inner")).joinToString(),
-                IUnknown::class)
+                    listOf("%T(aggregatingClass?.initAggregate())", "inner")).joinToString(),
+                IInspectable.IInspectable_Impl::class)
             add(")?.pointer\n")
-            addStatement("aggregatingClass?.inner = inner.getValue()")
+            addStatement("aggregatingClass?.inner = inner.getValue() as? %T", IUnknown::class)
             addStatement("return obj")
         }.build()
         addCode(cb)
@@ -731,7 +768,7 @@ private fun TypeSpec.Builder.generateCompositionFactoryConstructor(sparseMethod:
 
 
         val parameterNames = (userParams
-            .map { it.name } + "this as %T")
+            .map { it.name } + "aggregatingClass = this as %T")
 
         val cb = buildCodeBlock {
             beginControlFlow("pointer = if (this is %T)", IKotlinWinRTAggregate::class)

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateDelegate.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateDelegate.kt
@@ -82,7 +82,6 @@ private fun FileSpec.Builder.addImports() {
     addImport("com.github.knk190001.winrtbinding.runtime", "getValue")
     addImport("com.github.knk190001.winrtbinding.runtime", "toHandle")
     addImport("com.github.knk190001.winrtbinding.runtime", "handleToString")
-    addImport("com.github.knk190001.winrtbinding.runtime", "setValue")
     addImport("com.github.knk190001.winrtbinding.runtime", "iUnknownIID")
     addImport("com.github.knk190001.winrtbinding.runtime", "ABI")
     addImport("com.github.knk190001.winrtbinding.runtime", "invokeHR")
@@ -269,7 +268,11 @@ private fun TypeSpec.Builder.generateForeignFunction(sd: SparseDelegate) {
                     "guidFromNative(${param.name})"
                 } else if (param.type.namespace == "System" && param.type.name == "Boolean") {
                     "${param.name} != 0.toByte()"
-                } else {
+                } else if(param.type.namespace == "System" && param.type.name == "Object"){
+                    typeParameters.add(ClassName("com.github.knk190001.winrtbinding.runtime", "AnyABI"))
+                    typeParameters.add(param.type.asClassName())
+                    "%T.fromNative(${param.name}) as %T"
+                }else {
                     typeParameters.add(0, param.type.asClassName())
                     typeParameters.add(param.type.asTypeName())
                     "%T.ABI.fromNative($typeOfString${param.name}) as %T"

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateDelegate.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateDelegate.kt
@@ -83,6 +83,7 @@ private fun FileSpec.Builder.addImports() {
     addImport("com.github.knk190001.winrtbinding.runtime", "toHandle")
     addImport("com.github.knk190001.winrtbinding.runtime", "handleToString")
     addImport("com.github.knk190001.winrtbinding.runtime", "iUnknownIID")
+    addImport("com.github.knk190001.winrtbinding.runtime", "iAgileObjectIID")
     addImport("com.github.knk190001.winrtbinding.runtime", "ABI")
     addImport("com.github.knk190001.winrtbinding.runtime", "invokeHR")
     addImport("com.github.knk190001.winrtbinding.runtime", "checkHR")
@@ -390,7 +391,7 @@ private fun TypeSpec.Builder.generatePseudoConstructor(
             } else {
                 "IID"
             }
-            addStatement("newDelegate.init(listOf(ABI.$iidType,iUnknownIID), nativeFn)", Guid.IID::class, sd.guid)
+            addStatement("newDelegate.init(listOf(ABI.$iidType,iUnknownIID, iAgileObjectIID), nativeFn)", Guid.IID::class, sd.guid)
             addStatement("return newDelegate")
         }.build()
         addCode(cb)

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateGenericDelegate.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateGenericDelegate.kt
@@ -78,6 +78,7 @@ private fun FileSpec.Builder.addImports() {
     addImport("com.github.knk190001.winrtbinding.runtime.interop", "marshalToNative")
     addImport("com.github.knk190001.winrtbinding.runtime.interop", "runtimeFromNativeJF")
     addImport("com.github.knk190001.winrtbinding.runtime", "iUnknownIID")
+    addImport("com.github.knk190001.winrtbinding.runtime", "iAgileObjectIID")
     addImport("kotlin.reflect", "typeOf")
     addImport("kotlin.reflect.full", "createType")
     addImport("com.sun.jna", "Memory")
@@ -527,7 +528,7 @@ private fun TypeSpec.Builder.addBodyInvokeOperator(sparseDelegate: SparseDelegat
             addStatement("val newDelegate = %T(typeOf<%T>(), fn, %T(12))", delegateClass, delegateType, Memory::class)
             addStatement("val guid = guidOf<%T>()", delegateType)
             addStatement(
-                "newDelegate.init(listOf(%T.IID, guid), %T(stub.address().toRawLongValue()))",
+                "newDelegate.init(listOf(%T.IID, guid, iAgileObjectIID), %T(stub.address().toRawLongValue()))",
                 IUnknown.ABI::class,
                 Pointer::class
             )

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateGenericDelegate.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateGenericDelegate.kt
@@ -330,6 +330,12 @@ private fun CodeBlock.Builder.addToManagedStatementForParameter(
         return managedName
     }
 
+    if (param.type.namespace == "System" && param.type.name == "Object") {
+        val anyAbiClassName = ClassName("com.github.knk190001.winrtbinding.runtime", "AnyABI")
+        addStatement("val $managedName = %T.fromNative(${param.name})", anyAbiClassName)
+        return managedName
+    }
+
     if (param.type.name == "Boolean") {
         addStatement("val $managedName = ${param.name} != 0", param.type.asClassName())
         return managedName
@@ -477,7 +483,12 @@ fun CodeBlock.Builder.kTypeStatementFor(
     indent()
     typeReference.genericParameters!!.forEach {
         if (it.type == null) {
-            kTypeStatementFor(SparseTypeReference(it.name, ""), typeParameterIndexMap, projection, typeVarName = typeVarName)
+            kTypeStatementFor(
+                SparseTypeReference(it.name, ""),
+                typeParameterIndexMap,
+                projection,
+                typeVarName = typeVarName
+            )
         } else {
             kTypeStatementFor(it.type, typeParameterIndexMap, true, typeVarName = typeVarName)
         }

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateInterface.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateInterface.kt
@@ -6,6 +6,7 @@ import com.github.knk190001.winrtbinding.generator.model.entities.*
 import com.github.knk190001.winrtbinding.mapIfInstanceOf
 import com.github.knk190001.winrtbinding.runtime.annotations.*
 import com.github.knk190001.winrtbinding.runtime.base.*
+import com.github.knk190001.winrtbinding.runtime.com.IInspectable
 import com.github.knk190001.winrtbinding.runtime.com.IUnknown
 import com.github.knk190001.winrtbinding.runtime.com.IUnknownVtbl
 import com.github.knk190001.winrtbinding.runtime.com.IWinRTInterface
@@ -894,7 +895,7 @@ private fun TypeSpec.Builder.addParameterizedSIPtrProperties(
 }
 
 private fun TypeSpec.Builder.addParameterizedSuperInterfaces(sparseInterface: SparseInterface) {
-    addSuperinterface(IUnknown::class)
+    addSuperinterface(IInspectable::class)
     sparseInterface.superInterfaces.map {
         it.asTypeName(nestedClass = "WithDefault", usage = ClassNameUsage.ParentInterface)
     }.forEach(::addSuperinterface)
@@ -1355,7 +1356,6 @@ private fun CodeBlock.Builder.kTypeStatementFor(
 }
 
 private fun TypeSpec.Builder.addSuperInterfaces(sparseInterface: SparseInterface) {
-
     addSuperinterface(NativeMapped::class)
     addSuperinterface(IWinRTInterface::class)
 
@@ -1363,7 +1363,7 @@ private fun TypeSpec.Builder.addSuperInterfaces(sparseInterface: SparseInterface
         .map(SparseTypeReference::asTypeName)
         .forEach(this::addSuperinterface)
 
-    addSuperinterface(IUnknown::class)
+    addSuperinterface(IInspectable::class)
 }
 
 private fun TypeSpec.Builder.generateByReference(sparseInterface: SparseInterface) {

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateInterface.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateInterface.kt
@@ -364,17 +364,22 @@ private fun CodeBlock.Builder.addPrimitiveToManagedStatement(
         }
 
         "UInt64" -> {
-            addStatement("val $managedName = $paramName.toULong()", ULONG::class)
+            addStatement("val $managedName = $paramName.toULong()")
             return managedName
         }
 
         "UInt32" -> {
-            addStatement("val $managedName = $paramName.toUInt()", WinDef.UINT::class)
+            addStatement("val $managedName = $paramName.toUInt()")
             return managedName
         }
 
         "UInt16" -> {
-            addStatement("val $managedName = $paramName.toUShort()", WinDef.USHORT::class)
+            addStatement("val $managedName = $paramName.toUShort()")
+            return managedName
+        }
+
+        "Byte" -> {
+            addStatement("val $managedName = $paramName.toUByte()")
             return managedName
         }
 

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateStruct.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/generator/GenerateStruct.kt
@@ -145,7 +145,7 @@ private fun generateFieldProperty(it: SparseField): PropertySpec {
 
 private fun SparseTypeReference.isString() = isSystemType() && name == "String"
 
-private fun SparseTypeReference.isUnsigned() = isSystemType() && name.startsWith("UInt")
+private fun SparseTypeReference.isUnsigned() = isSystemType() && name.startsWith("UInt") || name == "Byte"
 
 private fun SparseTypeReference.defaultValue() = when (name) {
     "Boolean" -> "false"
@@ -157,7 +157,7 @@ private fun SparseTypeReference.defaultValue() = when (name) {
 }
 
 private fun SparseTypeReference.nativeToManagedUnsigned() = when (name) {
-    "UInt8" -> "toUByte()"
+    "Byte" -> "toUByte()"
     "UInt16" -> "toUShort()"
     "UInt32" -> "toUInt()"
     "UInt64" -> "toULong()"
@@ -165,7 +165,7 @@ private fun SparseTypeReference.nativeToManagedUnsigned() = when (name) {
 }
 
 private fun SparseTypeReference.managedToNativeUnsigned() = when (name) {
-    "UInt8" -> "toByte()"
+    "Byte" -> "toByte()"
     "UInt16" -> "toShort()"
     "UInt32" -> "toInt()"
     "UInt64" -> "toLong()"

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/ProjectionUtils.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/ProjectionUtils.kt
@@ -7,6 +7,7 @@ import com.github.knk190001.winrtbinding.runtime.annotations.ReceiveArray
 import com.github.knk190001.winrtbinding.runtime.base.IABI
 import com.github.knk190001.winrtbinding.runtime.base.IBaseABI
 import com.github.knk190001.winrtbinding.runtime.base.IParameterizedABI
+import com.github.knk190001.winrtbinding.runtime.com.IAgileObject
 import com.github.knk190001.winrtbinding.runtime.com.IUnknown
 import com.github.knk190001.winrtbinding.runtime.interop.*
 import com.sun.jna.*
@@ -204,10 +205,7 @@ fun Guid.GUID.ByReference.getValue(): Guid.GUID {
 typealias JNAPointer = Pointer
 
 val iUnknownIID = IUnknown.ABI.IID
-
-interface FromNativePolyfill<T> {
-    fun fromNative(segment: MemoryAddress): T
-}
+val iAgileObjectIID = IAgileObject.ABI.IID
 
 val String.Companion.ABI: IABI<String, MemoryAddress>
     get() = StringABI

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/WinRTImplUtil.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/WinRTImplUtil.kt
@@ -28,7 +28,7 @@ fun generateIInspectable(thisObj:Any, interfaces: Map<Guid.GUID, Pointer>): Pair
         }
         if (thisObj is IKotlinWinRTAggregate) {
             try {
-                returnValue.value = thisObj.inner?.QueryInterface(iid)
+                returnValue.value = thisObj.inner?.QueryInterface(iid)!!.iUnknown_Ptr
                 return@QueryInterface WinNT.S_OK
             } catch (e: Exception) {
                 return@QueryInterface WinNT.HRESULT(WinNT.E_NOTIMPL)

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/CompositionPointerType.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/CompositionPointerType.kt
@@ -1,6 +1,7 @@
 package com.github.knk190001.winrtbinding.runtime.base
 
 import com.github.knk190001.winrtbinding.runtime.JNAPointer
+import com.github.knk190001.winrtbinding.runtime.com.IInspectableVtbl
 import com.github.knk190001.winrtbinding.runtime.com.IUnknown
 import com.sun.jna.*
 import kotlin.reflect.jvm.javaConstructor
@@ -9,7 +10,8 @@ import kotlin.reflect.jvm.reflect
 open class CompositionPointerType(pointer: JNAPointer? = Pointer.NULL) : NativeMapped, ICompositionPointer {
     override var inner: IUnknown? = null
     private var principalPtr = pointer
-    override var vtbl: Memory? = null
+    override var interfacePointers: MutableList<Memory> = mutableListOf()
+    override var vtbl: IInspectableVtbl? = null
 
     var pointer:Pointer?
         get() {

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/IABI.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/IABI.kt
@@ -1,5 +1,5 @@
 package com.github.knk190001.winrtbinding.runtime.base
 
-interface IABI<Managed : Any, Native : Any>: IBaseABI<Managed, Native> {
+interface IABI<Managed, Native : Any>: IBaseABI<Managed, Native> {
     fun fromNative(obj: Native): Managed
 }

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/ICompositionPointer.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/ICompositionPointer.kt
@@ -1,10 +1,11 @@
 package com.github.knk190001.winrtbinding.runtime.base
 
+import com.github.knk190001.winrtbinding.runtime.com.IInspectableVtbl
 import com.github.knk190001.winrtbinding.runtime.com.IUnknown
 import com.sun.jna.Memory
-import com.sun.jna.Pointer
 
 interface ICompositionPointer {
     var inner: IUnknown?
-    var vtbl: Memory?
+    var interfacePointers: MutableList<Memory>
+    var vtbl: IInspectableVtbl?
 }

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/IKotlinWinRTAggregate.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/base/IKotlinWinRTAggregate.kt
@@ -3,27 +3,16 @@ package com.github.knk190001.winrtbinding.runtime.base
 import com.github.knk190001.winrtbinding.runtime.*
 import com.github.knk190001.winrtbinding.runtime.annotations.AggregateImplements
 import com.github.knk190001.winrtbinding.runtime.annotations.InterfaceMethod
-import com.github.knk190001.winrtbinding.runtime.com.IInspectableVtbl
-import com.github.knk190001.winrtbinding.runtime.com.IUnknown
-import com.github.knk190001.winrtbinding.runtime.com.IUnknownVtbl
 import com.sun.jna.Memory
 import com.sun.jna.Native
-import com.sun.jna.NativeMapped
 import com.sun.jna.Pointer
-import com.sun.jna.platform.win32.Guid
-import com.sun.jna.platform.win32.WinDef
-import com.sun.jna.platform.win32.WinNT
-import com.sun.jna.platform.win32.WinNT.HRESULT
 import java.lang.foreign.Linker
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.MemorySession
-import java.lang.invoke.MethodHandles
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.hasAnnotation
-import kotlin.reflect.jvm.javaMethod
-import kotlin.reflect.jvm.jvmName
 
 interface IKotlinWinRTAggregate: ICompositionPointer {
     fun initAggregate(): Pointer{
@@ -36,6 +25,7 @@ interface IKotlinWinRTAggregate: ICompositionPointer {
         }
 
         val (objPtr, baseVtbl) = generateIInspectable(this, interfaces)
+        vtbl = baseVtbl
 
         interfaces.values.forEach {
             backFillIInspectable(baseVtbl, it)
@@ -46,7 +36,8 @@ interface IKotlinWinRTAggregate: ICompositionPointer {
 
     private fun generateInterface(kClass: KClass<*>, handleProvider: INativeHandleProvider): Pointer {
         val bufferSize = (handleProvider.handles.size + 6) * 8L
-        vtbl = Memory(bufferSize)
+        val vtbl = Memory(bufferSize)
+        interfacePointers += vtbl
 
         val ptrToVtbl = Memory(Native.POINTER_SIZE.toLong())
         ptrToVtbl.setPointer(0, vtbl)
@@ -73,7 +64,7 @@ interface IKotlinWinRTAggregate: ICompositionPointer {
                 upcallStub
             }
             .map { (index: Int, stub: MemorySegment) -> (index + 6) * 8L to stub.address().toPointer() }
-            .forEach { (offset, fnPtr) -> vtbl!!.setPointer(offset, fnPtr) }
+            .forEach { (offset, fnPtr) -> vtbl.setPointer(offset, fnPtr) }
 
         return ptrToVtbl
     }

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/IAgileObject.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/IAgileObject.kt
@@ -1,0 +1,9 @@
+package com.github.knk190001.winrtbinding.runtime.com
+
+import com.sun.jna.platform.win32.Guid.IID
+
+interface IAgileObject {
+    object ABI {
+        val IID = IID("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90")
+    }
+}

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/IInspectable.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/IInspectable.kt
@@ -5,15 +5,12 @@ import com.github.knk190001.winrtbinding.runtime.annotations.ABIMarker
 import com.github.knk190001.winrtbinding.runtime.base.IABI
 import com.github.knk190001.winrtbinding.runtime.interop.IntByReference
 import com.github.knk190001.winrtbinding.runtime.interop.ULongByReference
+import com.sun.jna.*
 import com.sun.jna.Function
-import com.sun.jna.NativeMapped
-import com.sun.jna.Pointer
-import com.sun.jna.PointerType
 import com.sun.jna.platform.win32.Guid
 import com.sun.jna.platform.win32.Guid.GUID
 import com.sun.jna.platform.win32.WinNT
 import com.sun.jna.ptr.PointerByReference
-import java.lang.RuntimeException
 import java.lang.foreign.MemoryAddress
 import java.lang.foreign.MemoryLayout
 import java.lang.foreign.ValueLayout
@@ -21,9 +18,10 @@ import kotlin.reflect.typeOf
 
 
 @ABIMarker(IInspectable::class)
+@com.github.knk190001.winrtbinding.runtime.annotations.Guid("af86e2e0b12d4c6a9c5ad7aa65101e90")
 interface IInspectable : IUnknown, NativeMapped, IWinRTInterface {
     fun GetIids(iidCount: ULongByReference, iids: MutableList<Guid.IID>) {
-        val fnPtr = iUnknown_Vtbl.getPointer(3)
+        val fnPtr = iUnknown_Vtbl.getPointer(3L * Native.POINTER_SIZE)
         val fn = Function.getFunction(fnPtr, Function.ALT_CONVENTION)
         val result = PointerByReference()
         val hr = fn.invokeHR(arrayOf(iUnknown_Ptr, iidCount, result))
@@ -32,7 +30,7 @@ interface IInspectable : IUnknown, NativeMapped, IWinRTInterface {
     }
 
     fun GetRuntimeClassName(): String {
-        val fnPtr = iUnknown_Vtbl.getPointer(4)
+        val fnPtr = iUnknown_Vtbl.getPointer(4L * Native.POINTER_SIZE)
         val fn = Function.getFunction(fnPtr, Function.ALT_CONVENTION)
         val result = WinNT.HANDLEByReference()
         val hr = fn.invokeHR(arrayOf(result))
@@ -41,7 +39,7 @@ interface IInspectable : IUnknown, NativeMapped, IWinRTInterface {
     }
 
     fun GetTrustLevel(): TrustLevel {
-        val fnPtr = iUnknown_Vtbl.getPointer(5)
+        val fnPtr = iUnknown_Vtbl.getPointer(5L * Native.POINTER_SIZE)
         val fn = Function.getFunction(fnPtr, Function.ALT_CONVENTION)
         val result = IntByReference()
         val hr = fn.invokeHR(arrayOf(result))
@@ -49,7 +47,7 @@ interface IInspectable : IUnknown, NativeMapped, IWinRTInterface {
         return TrustLevel.BasicTrust.fromNative(result.value, null) as TrustLevel
     }
 
-    class IInspectable_Impl(ptr: Pointer = Pointer.NULL): PointerType(ptr), IInspectable {
+    class IInspectable_Impl(ptr: Pointer? = Pointer.NULL): PointerType(ptr), IInspectable {
         override val iUnknown_Ptr: Pointer
             get() = pointer
 

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/IInspectable.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/IInspectable.kt
@@ -1,0 +1,72 @@
+package com.github.knk190001.winrtbinding.runtime.com
+
+import com.github.knk190001.winrtbinding.runtime.*
+import com.github.knk190001.winrtbinding.runtime.annotations.ABIMarker
+import com.github.knk190001.winrtbinding.runtime.base.IABI
+import com.github.knk190001.winrtbinding.runtime.interop.IntByReference
+import com.github.knk190001.winrtbinding.runtime.interop.ULongByReference
+import com.sun.jna.Function
+import com.sun.jna.NativeMapped
+import com.sun.jna.Pointer
+import com.sun.jna.PointerType
+import com.sun.jna.platform.win32.Guid
+import com.sun.jna.platform.win32.Guid.GUID
+import com.sun.jna.platform.win32.WinNT
+import com.sun.jna.ptr.PointerByReference
+import java.lang.RuntimeException
+import java.lang.foreign.MemoryAddress
+import java.lang.foreign.MemoryLayout
+import java.lang.foreign.ValueLayout
+import kotlin.reflect.typeOf
+
+
+@ABIMarker(IInspectable::class)
+interface IInspectable : IUnknown, NativeMapped, IWinRTInterface {
+    fun GetIids(iidCount: ULongByReference, iids: MutableList<Guid.IID>) {
+        val fnPtr = iUnknown_Vtbl.getPointer(3)
+        val fn = Function.getFunction(fnPtr, Function.ALT_CONVENTION)
+        val result = PointerByReference()
+        val hr = fn.invokeHR(arrayOf(iUnknown_Ptr, iidCount, result))
+        readReceiveArrayIntoList(typeOf<GUID>(), iidCount, result, iids)
+        checkHR(hr)
+    }
+
+    fun GetRuntimeClassName(): String {
+        val fnPtr = iUnknown_Vtbl.getPointer(4)
+        val fn = Function.getFunction(fnPtr, Function.ALT_CONVENTION)
+        val result = WinNT.HANDLEByReference()
+        val hr = fn.invokeHR(arrayOf(result))
+        checkHR(hr)
+        return result.value.handleToString()
+    }
+
+    fun GetTrustLevel(): TrustLevel {
+        val fnPtr = iUnknown_Vtbl.getPointer(5)
+        val fn = Function.getFunction(fnPtr, Function.ALT_CONVENTION)
+        val result = IntByReference()
+        val hr = fn.invokeHR(arrayOf(result))
+        checkHR(hr)
+        return TrustLevel.BasicTrust.fromNative(result.value, null) as TrustLevel
+    }
+
+    class IInspectable_Impl(ptr: Pointer = Pointer.NULL): PointerType(ptr), IInspectable {
+        override val iUnknown_Ptr: Pointer
+            get() = pointer
+
+        override val iUnknown_Vtbl: Pointer
+            get() = pointer.getPointer(0)
+    }
+
+    object ABI: IABI<IInspectable, MemoryAddress> {
+        override fun fromNative(obj: MemoryAddress): IInspectable {
+            return IInspectable_Impl(obj.toPointer())
+        }
+
+        override val layout: MemoryLayout = ValueLayout.ADDRESS
+
+        override fun toNative(obj: IInspectable): MemoryAddress {
+            return obj.iUnknown_Ptr.toMemoryAddress()
+        }
+
+    }
+}

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/TrustLevel.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/com/TrustLevel.kt
@@ -1,0 +1,29 @@
+package com.github.knk190001.winrtbinding.runtime.com
+
+import com.sun.jna.FromNativeContext
+import com.sun.jna.NativeMapped
+
+enum class TrustLevel(val value: Int) : NativeMapped {
+    BasicTrust(0),
+    PartialTrust(1),
+    FullTrust(2);
+
+
+    override fun fromNative(p0: Any?, p1: FromNativeContext?): Any {
+        if (p0 !is Int) throw IllegalArgumentException()
+        return when (p0) {
+            0 -> BasicTrust
+            1 -> PartialTrust
+            2 -> FullTrust
+            else -> throw IllegalArgumentException()
+        }
+    }
+
+    override fun toNative(): Any {
+        return this.value
+    }
+
+    override fun nativeType(): Class<*> {
+        return Integer::class.java
+    }
+}

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/ABIPolyfills.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/ABIPolyfills.kt
@@ -19,9 +19,10 @@ val AnyABI = Class.forName(AnyABIClass).kotlin.objectInstance as IABI<Any, Memor
 
 val abiPolyfillMap = mapOf<KClass<*>, IBaseABI<*, *>>(
     String::class to StringABI,
-    USHORT::class to UShortABI,
-    WinDef.UINT::class to UIntABI,
-    WinDef.ULONG::class to ULongABI,
+    UByte::class to UByteABI,
+    UShort::class to UShortABI,
+    UInt::class to UIntABI,
+    ULong::class to ULongABI,
     Float::class to FloatABI,
     Double::class to DoubleABI,
     Boolean::class to BooleanABI,
@@ -33,6 +34,19 @@ val abiPolyfillMap = mapOf<KClass<*>, IBaseABI<*, *>>(
     Char::class to CharABI,
     Any::class to AnyABI
 )
+
+object UByteABI : IABI<UByte, Byte> {
+    override fun fromNative(obj: Byte): UByte {
+        return obj.toUByte()
+    }
+
+    override val layout: MemoryLayout
+        get() = ValueLayout.JAVA_BYTE
+
+    override fun toNative(obj: UByte): Byte {
+        return obj.toByte()
+    }
+}
 
 object StringABI: IABI<String, MemoryAddress> {
     override fun fromNative(obj: MemoryAddress): String {

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/ABIPolyfills.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/ABIPolyfills.kt
@@ -13,6 +13,10 @@ import com.sun.jna.platform.win32.WinNT.HANDLE
 import java.lang.foreign.*
 import kotlin.reflect.KClass
 
+const val AnyABIClass = "com.github.knk190001.winrtbinding.runtime.AnyABI"
+@Suppress("UNCHECKED_CAST")
+val AnyABI = Class.forName(AnyABIClass).kotlin.objectInstance as IABI<Any, MemoryAddress>
+
 val abiPolyfillMap = mapOf<KClass<*>, IBaseABI<*, *>>(
     String::class to StringABI,
     USHORT::class to UShortABI,
@@ -27,6 +31,7 @@ val abiPolyfillMap = mapOf<KClass<*>, IBaseABI<*, *>>(
     Byte::class to ByteABI,
     GUID::class to GUIDABI,
     Char::class to CharABI,
+    Any::class to AnyABI
 )
 
 object StringABI: IABI<String, MemoryAddress> {
@@ -216,6 +221,3 @@ object CharABI : IABI<Char, Char> {
     }
 
 }
-
-
-

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/RuntimeGuidGenerator.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/RuntimeGuidGenerator.kt
@@ -7,9 +7,6 @@ import com.github.knk190001.winrtbinding.runtime.base.Delegate
 import com.github.knk190001.winrtbinding.runtime.com.*
 import com.sun.jna.Structure
 import com.sun.jna.platform.win32.Guid.IID
-import com.sun.jna.platform.win32.WinDef
-import com.sun.jna.platform.win32.WinDef.UINT
-import com.sun.jna.platform.win32.WinDef.ULONG
 import memeid.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -36,24 +33,25 @@ object RuntimeGuidGenerator {
             return getSignature(type.withNullability(false))
         }
         when (type) {
-            typeOf<IUnknown>() -> return "cinterface(IInspectable)"
+            typeOf<Any>() -> return "cinterface(IInspectable)"
             typeOf<String>() -> return "string"
             else -> {}
         }
         if (type.isValueType()) {
             return when (type) {
-                typeOf<Boolean>() -> "b1"
                 typeOf<Byte>() -> "i1"
-                typeOf<Char>() -> "c2"
-                typeOf<Double>() -> "f8"
-                typeOf<IID>() -> "g16"
+                typeOf<UByte>() -> "u1"
                 typeOf<Short>() -> "i2"
+                typeOf<UShort>() -> "u2"
                 typeOf<Int>() -> "i4"
+                typeOf<UInt>() -> "u4"
                 typeOf<Long>() -> "i8"
+                typeOf<ULong>() -> "u8"
                 typeOf<Float>() -> "f4"
-                typeOf<WinDef.USHORT>() -> "u2"
-                typeOf<UINT>() -> "u4"
-                typeOf<ULONG>() -> "u8"
+                typeOf<Double>() -> "f8"
+                typeOf<Boolean>() -> "b1"
+                typeOf<Char>() -> "c2"
+                typeOf<IID>() -> "g16"
                 else -> {
                     if (type.isSubtypeOf(typeOf<Enum<*>>()) || type.isSubtypeOf(typeOf<Structure>())) {
                         return type.annotationOfType<Signature>()!!.signature
@@ -101,19 +99,19 @@ fun guidOf(type: KType): IID {
 private fun KType.isValueType(): Boolean {
     if (classifier !is KClass<*>) return false
     when (classifier as KClass<*>) {
-        Boolean::class -> return true
         Byte::class -> return true
-        Char::class -> return true
-        Double::class -> return true
-        IID::class -> return true
+        UByte::class -> return true
         Short::class -> return true
+        UShort::class -> return true
         Int::class -> return true
+        UInt::class -> return true
         Long::class -> return true
-        UINT::class -> return true
+        ULong::class -> return true
         Float::class -> return true
-        WinDef.USHORT::class -> return true
-        UINT::class -> return true
-        ULONG::class -> return true
+        Double::class -> return true
+        Boolean::class -> return true
+        Char::class -> return true
+        IID::class -> return true
         else -> {}
     }
     return (classifier as KClass<*>).isSubclassOf(Enum::class) ||

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/RuntimeMarshal.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/RuntimeMarshal.kt
@@ -8,10 +8,7 @@ import com.sun.jna.Pointer
 import com.sun.jna.Structure
 import com.sun.jna.platform.win32.WinNT.HANDLE
 import java.lang.foreign.MemoryAddress
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
@@ -76,6 +73,9 @@ fun <T : Any> marshalToNative(t: T?, type: KType): Any? {
     }
     if (!type.jvmErasure.isInstance(t) && (abi is IParameterizedNativePeerProvider)) {
         return abi.makeNativePeer(type, t)
+    }
+    if (type == typeOf<Any>() && t !is NativeMapped && t !is Pointer && t !is Structure) {
+        return AnyABI.toNative(t as Any).toPointer()
     }
 
     val marshal: Marshal<T, *> = marshals.singleOrNull {

--- a/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/RuntimeMarshal.kt
+++ b/code-generator/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/interop/RuntimeMarshal.kt
@@ -121,4 +121,3 @@ class StringMarshal : Marshal<String, HANDLE> {
     }
 
 }
-

--- a/example/src/main/kotlin/Main.kt
+++ b/example/src/main/kotlin/Main.kt
@@ -11,6 +11,8 @@ import Windows.Media.VideoFrame
 import Windows.Storage.FileAccessMode
 import Windows.Storage.StorageFile
 import com.github.knk190001.winrtbinding.runtime.WinRT
+import com.github.knk190001.winrtbinding.runtime.cast
+import com.github.knk190001.winrtbinding.runtime.com.IUnknown
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import java.nio.file.Path
@@ -130,8 +132,7 @@ fun evaluateModel(session: LearningModelSession, binding: LearningModelBinding):
     println("Outputs: " + outputs.size)
     val kvp = outputs.entries.first()
     println("Key: ${kvp.key}")
-    val o = outputs["softmaxout_1"]!!
-    val resultTensor = TensorFloat(o.iUnknown_Ptr)
+    val resultTensor = (outputs["softmaxout_1"]!! as IUnknown).cast<TensorFloat>()
     return resultTensor.GetAsVectorView()!!
 }
 

--- a/example/src/main/kotlin/MyApplication.kt
+++ b/example/src/main/kotlin/MyApplication.kt
@@ -4,8 +4,10 @@ import Microsoft.UI.Xaml.Controls.*
 import Microsoft.UI.Xaml.Markup.IXamlMetadataProvider
 import Microsoft.UI.Xaml.Media.MicaBackdrop
 import Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsXamlMetaDataProvider
+import com.github.knk190001.winrtbinding.foundation.collections.Reference
 import com.github.knk190001.winrtbinding.runtime.annotations.AggregateImplements
 import com.github.knk190001.winrtbinding.runtime.base.IKotlinWinRTAggregate
+
 import java.math.BigInteger
 
 @AggregateImplements([IApplicationOverrides::class, IXamlMetadataProvider::class])
@@ -35,14 +37,17 @@ class MyApplication : Application(), IApplicationOverrides, IKotlinWinRTAggregat
             }
         }
 
-        val stackPanel = StackPanel().apply {
+        val toggle = ToggleSwitch().apply {
+            Header = Reference("Header")
+        }
 
+        val stackPanel = StackPanel().apply {
             HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center
             VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center
             val children = Children!!
             children += button
             children += labelText
-
+            children += toggle
         }
 
         val w = Window().apply {

--- a/example/src/main/kotlin/MyApplication.kt
+++ b/example/src/main/kotlin/MyApplication.kt
@@ -4,7 +4,6 @@ import Microsoft.UI.Xaml.Controls.*
 import Microsoft.UI.Xaml.Markup.IXamlMetadataProvider
 import Microsoft.UI.Xaml.Media.MicaBackdrop
 import Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsXamlMetaDataProvider
-import com.github.knk190001.winrtbinding.foundation.collections.Reference
 import com.github.knk190001.winrtbinding.runtime.annotations.AggregateImplements
 import com.github.knk190001.winrtbinding.runtime.base.IKotlinWinRTAggregate
 
@@ -38,7 +37,7 @@ class MyApplication : Application(), IApplicationOverrides, IKotlinWinRTAggregat
         }
 
         val toggle = ToggleSwitch().apply {
-            Header = Reference("Header")
+            Header = "Header"
         }
 
         val stackPanel = StackPanel().apply {

--- a/metadata/build.gradle.kts
+++ b/metadata/build.gradle.kts
@@ -29,3 +29,7 @@ publishing {
         }
     }
 }
+
+java {
+    withSourcesJar()
+}

--- a/win-app-sdk/build.gradle.kts
+++ b/win-app-sdk/build.gradle.kts
@@ -56,10 +56,18 @@ java {
     }
 }
 
-val codeGeneratorBuild = rootProject.project(":code-generator").tasks.named("build")
 
-tasks.named("generateMain") {
-    dependsOn(codeGeneratorBuild)
+gradle.projectsEvaluated {
+    val codeGeneratorBuild = rootProject.project(":code-generator").tasks.named("build")
+    tasks.named("generateMain") {
+        dependsOn(codeGeneratorBuild)
+
+    }
+
+    val winAppSdkGenerateMain = tasks.named("generateMain")
+    tasks.named("sourcesJar") {
+        dependsOn(winAppSdkGenerateMain)
+    }
 }
 
 publishing {
@@ -71,4 +79,8 @@ publishing {
             version = "1.0"
         }
     }
+}
+
+java {
+    withSourcesJar()
 }

--- a/winrt/build.gradle.kts
+++ b/winrt/build.gradle.kts
@@ -64,9 +64,16 @@ java {
     }
 }
 
-val codeGeneratorBuild = rootProject.project(":code-generator").tasks.named("build")
-tasks.named("generateMain") {
-    dependsOn(codeGeneratorBuild)
+gradle.projectsEvaluated {
+    val codeGeneratorBuild = rootProject.project(":code-generator").tasks.named("build")
+    tasks.named("generateMain") {
+        dependsOn(codeGeneratorBuild)
+    }
+
+    val winrtGenerateMain = tasks.named("generateMain")
+    tasks.named("sourcesJar") {
+        dependsOn(winrtGenerateMain)
+    }
 }
 
 publishing {
@@ -80,3 +87,6 @@ publishing {
     }
 }
 
+java {
+    withSourcesJar()
+}

--- a/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/foundation/collections/Reference.kt
+++ b/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/foundation/collections/Reference.kt
@@ -1,0 +1,267 @@
+package com.github.knk190001.winrtbinding.foundation.collections
+
+import Windows.Foundation.*
+import com.github.knk190001.winrtbinding.runtime.annotations.ObjectImplements
+import com.github.knk190001.winrtbinding.runtime.base.Delegate
+import com.github.knk190001.winrtbinding.runtime.base.KotlinWinRTObject
+import com.github.knk190001.winrtbinding.runtime.com.IUnknown
+import com.sun.jna.platform.win32.Guid
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.typeOf
+
+
+@Suppress("UNCHECKED_CAST")
+@ObjectImplements([IReference::class, IPropertyValue::class])
+class Reference<T>(override val _Windows_FoundationIReference_Type: KType? = null, override val Value: T) :
+    KotlinWinRTObject(), IReference<T> {
+
+    @Suppress("UNCHECKED_CAST")
+    constructor() : this(null, null as T)
+
+    init {
+        if (_Windows_FoundationIReference_Type != null) {
+            initObj()
+        }
+    }
+
+    companion object {
+        inline operator fun <reified T> invoke(value: T): Reference<T> {
+            return Reference(
+                IReference::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, typeOf<T>()))),
+                value
+            )
+        }
+
+        private fun propertyTypeOf(type: KType): PropertyType {
+            val clazz = type.jvmErasure
+            return when (clazz) {
+                Unit::class -> PropertyType.Empty
+                UByte::class -> PropertyType.UInt8
+                Short::class -> PropertyType.Int16
+                UShort::class -> PropertyType.UInt16
+                Int::class -> PropertyType.Int32
+                UInt::class -> PropertyType.UInt32
+                Long::class -> PropertyType.Int64
+                ULong::class -> PropertyType.UInt64
+                Float::class -> PropertyType.Single
+                Double::class -> PropertyType.Double
+                Char::class -> PropertyType.Char16
+                Boolean::class -> PropertyType.Boolean
+                String::class -> PropertyType.String
+                DateTime::class -> PropertyType.DateTime
+                TimeSpan::class -> PropertyType.TimeSpan
+                Guid.GUID::class -> PropertyType.Guid
+                Point::class -> PropertyType.Point
+                Size::class -> PropertyType.Size
+                Rect::class -> PropertyType.Rect
+                Array::class -> propertyTypeOf(type.arguments[0].type!!)
+                else -> if (type.isSubtypeOf(typeOf<Delegate>())) {
+                    PropertyType.OtherType
+                } else {
+                    PropertyType.Inspectable
+                }
+            }
+        }
+    }
+
+    override val Type: PropertyType
+        get() = propertyTypeOf(_Windows_FoundationIReference_Type!!.arguments[0].type!!)
+
+    override val IsNumericScalar: Boolean
+        get() = when (Type) {
+            PropertyType.UInt8, PropertyType.Int16, PropertyType.UInt16, PropertyType.Int32, PropertyType.UInt32,
+            PropertyType.Int64, PropertyType.UInt64, PropertyType.Single, PropertyType.Double -> true
+            else -> false
+        }
+
+    override fun GetUInt8(): Byte {
+        if (Type != PropertyType.UInt8) throw IllegalStateException()
+        return Value as Byte
+    }
+
+
+    override fun GetInt16(): Short {
+        if (Type != PropertyType.Int16) throw IllegalStateException()
+        return Value as Short
+    }
+
+    override fun GetUInt16(): UShort {
+        if (Type != PropertyType.UInt16) throw IllegalStateException()
+        return Value as UShort
+    }
+
+    override fun GetInt32(): Int {
+        if (Type != PropertyType.Int32) throw IllegalStateException()
+        return Value as Int
+    }
+
+    override fun GetUInt32(): UInt {
+        if (Type != PropertyType.UInt32) throw IllegalStateException()
+        return Value as UInt
+    }
+
+    override fun GetInt64(): Long {
+        if (Type != PropertyType.Int64) throw IllegalStateException()
+        return Value as Long
+    }
+
+    override fun GetUInt64(): ULong {
+        if (Type != PropertyType.UInt64) throw IllegalStateException()
+        return Value as ULong
+    }
+
+    override fun GetSingle(): Float {
+        if (Type != PropertyType.Single) throw IllegalStateException()
+        return Value as Float
+    }
+
+    override fun GetDouble(): Double {
+        if (Type != PropertyType.Double) throw IllegalStateException()
+        return Value as Double
+    }
+
+    override fun GetChar16(): Char {
+        if (Type != PropertyType.Char16) throw IllegalStateException()
+        return Value as Char
+    }
+
+    override fun GetBoolean(): Boolean {
+        if (Type != PropertyType.Boolean) throw IllegalStateException()
+        return Value as Boolean
+    }
+
+    override fun GetString(): String {
+        if (Type != PropertyType.String) throw IllegalStateException()
+        return Value as String
+    }
+
+    override fun GetGuid(): Guid.GUID {
+        if (Type != PropertyType.Guid) throw IllegalStateException()
+        return Value as Guid.GUID
+    }
+
+    override fun GetDateTime(): DateTime {
+        if (Type != PropertyType.DateTime) throw IllegalStateException()
+        return Value as DateTime
+    }
+
+    override fun GetTimeSpan(): TimeSpan {
+        if (Type != PropertyType.TimeSpan) throw IllegalStateException()
+        return Value as TimeSpan
+    }
+
+    override fun GetPoint(): Point {
+        if (Type != PropertyType.Point) throw IllegalStateException()
+        return Value as Point
+    }
+
+    override fun GetSize(): Size {
+        if (Type != PropertyType.Size) throw IllegalStateException()
+        return Value as Size
+    }
+
+    override fun GetRect(): Rect {
+        if (Type != PropertyType.Rect) throw IllegalStateException()
+        return Value as Rect
+    }
+
+    override fun GetUInt8Array(value: MutableList<Byte>) {
+        if (Type != PropertyType.UInt8Array) throw IllegalStateException()
+        value.addAll(Value as List<Byte>)
+    }
+
+    override fun GetInt16Array(value: MutableList<Short>) {
+if (Type != PropertyType.Int16Array) throw IllegalStateException()
+        value.addAll(Value as List<Short>)
+    }
+
+    override fun GetUInt16Array(value: MutableList<UShort>) {
+        if (Type != PropertyType.UInt16Array) throw IllegalStateException()
+        value.addAll(Value as List<UShort>)
+    }
+
+    override fun GetInt32Array(value: MutableList<Int>) {
+        if (Type != PropertyType.Int32Array) throw IllegalStateException()
+        value.addAll(Value as List<Int>)
+    }
+
+    override fun GetUInt32Array(value: MutableList<UInt>) {
+        if (Type != PropertyType.UInt32Array) throw IllegalStateException()
+        value.addAll(Value as List<UInt>)
+    }
+
+    override fun GetInt64Array(value: MutableList<Long>) {
+        if (Type != PropertyType.Int64Array) throw IllegalStateException()
+        value.addAll(Value as List<Long>)
+    }
+
+    override fun GetUInt64Array(value: MutableList<ULong>) {
+        if (Type != PropertyType.UInt64Array) throw IllegalStateException()
+        value.addAll(Value as List<ULong>)
+    }
+
+    override fun GetSingleArray(value: MutableList<Float>) {
+        if (Type != PropertyType.SingleArray) throw IllegalStateException()
+        value.addAll(Value as List<Float>)
+    }
+
+    override fun GetDoubleArray(value: MutableList<Double>) {
+        if (Type != PropertyType.DoubleArray) throw IllegalStateException()
+        value.addAll(Value as List<Double>)
+    }
+
+    override fun GetChar16Array(value: MutableList<Char>) {
+        if (Type != PropertyType.Char16Array) throw IllegalStateException()
+        value.addAll(Value as List<Char>)
+    }
+
+    override fun GetBooleanArray(value: MutableList<Boolean>) {
+        if (Type != PropertyType.BooleanArray) throw IllegalStateException()
+        value.addAll(Value as List<Boolean>)
+    }
+
+    override fun GetStringArray(value: MutableList<String?>) {
+        if (Type != PropertyType.StringArray) throw IllegalStateException()
+        value.addAll(Value as List<String?>)
+    }
+
+    override fun GetInspectableArray(value: MutableList<IUnknown?>) {
+        if (Type != PropertyType.InspectableArray) throw IllegalStateException()
+        value.addAll(Value as List<IUnknown?>)
+    }
+
+    override fun GetGuidArray(value: MutableList<Guid.GUID?>) {
+        if (Type != PropertyType.GuidArray) throw IllegalStateException()
+        value.addAll(Value as List<Guid.GUID?>)
+    }
+
+    override fun GetDateTimeArray(value: MutableList<DateTime?>) {
+        if (Type != PropertyType.DateTimeArray) throw IllegalStateException()
+        value.addAll(Value as List<DateTime?>)
+    }
+
+    override fun GetTimeSpanArray(value: MutableList<TimeSpan?>) {
+        if (Type != PropertyType.TimeSpanArray) throw IllegalStateException()
+        value.addAll(Value as List<TimeSpan?>)
+    }
+
+    override fun GetPointArray(value: MutableList<Point?>) {
+        if (Type != PropertyType.PointArray) throw IllegalStateException()
+        value.addAll(Value as List<Point?>)
+    }
+
+    override fun GetSizeArray(value: MutableList<Size?>) {
+        if (Type != PropertyType.SizeArray) throw IllegalStateException()
+        value.addAll(Value as List<Size?>)
+    }
+
+    override fun GetRectArray(value: MutableList<Rect?>) {
+        if (Type != PropertyType.RectArray) throw IllegalStateException()
+        value.addAll(Value as List<Rect?>)
+    }
+}

--- a/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/AnyABI.kt
+++ b/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/AnyABI.kt
@@ -1,0 +1,119 @@
+package com.github.knk190001.winrtbinding.runtime
+
+import Windows.Foundation.*
+import com.github.knk190001.winrtbinding.runtime.base.IABI
+import com.github.knk190001.winrtbinding.runtime.com.IInspectable
+import com.github.knk190001.winrtbinding.runtime.com.IUnknown
+import com.sun.jna.platform.win32.Guid.GUID
+import java.lang.foreign.MemoryAddress
+import java.lang.foreign.MemoryLayout
+import java.lang.foreign.ValueLayout
+
+object AnyABI: IABI<Any, MemoryAddress> {
+    override fun fromNative(obj: MemoryAddress): Any {
+        val it = IUnknown.ABI.makeIUnknown(obj.toPointer())
+        if (it.instanceOf<IPropertyValue>()) {
+            val prop = it.cast<IPropertyValue>()
+            return when (prop.Type) {
+                PropertyType.Empty -> Unit
+                PropertyType.UInt8 -> prop.GetUInt8()
+                PropertyType.Int16 -> prop.GetInt16()
+                PropertyType.UInt16 -> prop.GetUInt16()
+                PropertyType.Int32 -> prop.GetInt32()
+                PropertyType.UInt32 -> prop.GetUInt32()
+                PropertyType.Int64 -> prop.GetInt64()
+                PropertyType.UInt64 -> prop.GetUInt64()
+                PropertyType.Single -> prop.GetSingle()
+                PropertyType.Double -> prop.GetDouble()
+                PropertyType.Char16 -> prop.GetChar16()
+                PropertyType.Boolean -> prop.GetBoolean()
+                PropertyType.String -> prop.GetString()!!
+                PropertyType.Inspectable -> it
+                PropertyType.DateTime -> prop.GetDateTime()!!
+                PropertyType.TimeSpan -> prop.GetTimeSpan()!!
+                PropertyType.Guid -> prop.GetGuid()!!
+                PropertyType.Point -> prop.GetPoint()!!
+                PropertyType.Size -> prop.GetSize()!!
+                PropertyType.Rect -> prop.GetRect()!!
+                PropertyType.OtherType -> throw IllegalArgumentException("OtherType is not supported")
+                PropertyType.UInt8Array -> mutableListOf<UByte>().apply { prop.GetUInt8Array(this) }
+                PropertyType.Int16Array -> mutableListOf<Short>().apply { prop.GetInt16Array(this) }
+                PropertyType.UInt16Array -> mutableListOf<UShort>().apply { prop.GetUInt16Array(this) }
+                PropertyType.Int32Array -> mutableListOf<Int>().apply { prop.GetInt32Array(this) }
+                PropertyType.UInt32Array -> mutableListOf<UInt>().apply { prop.GetUInt32Array(this) }
+                PropertyType.Int64Array -> mutableListOf<Long>().apply { prop.GetInt64Array(this) }
+                PropertyType.UInt64Array -> mutableListOf<ULong>().apply { prop.GetUInt64Array(this) }
+                PropertyType.SingleArray -> mutableListOf<Float>().apply { prop.GetSingleArray(this) }
+                PropertyType.DoubleArray -> mutableListOf<Double>().apply { prop.GetDoubleArray(this) }
+                PropertyType.Char16Array -> mutableListOf<Char>().apply { prop.GetChar16Array(this) }
+                PropertyType.BooleanArray -> mutableListOf<Boolean>().apply { prop.GetBooleanArray(this) }
+                PropertyType.StringArray -> mutableListOf<String?>().apply { prop.GetStringArray(this) }
+                PropertyType.InspectableArray -> mutableListOf<Any?>().apply { prop.GetInspectableArray(this) }
+                PropertyType.DateTimeArray -> mutableListOf<DateTime?>().apply { prop.GetDateTimeArray(this) }
+                PropertyType.TimeSpanArray -> mutableListOf<TimeSpan?>().apply { prop.GetTimeSpanArray(this) }
+                PropertyType.GuidArray -> mutableListOf<GUID?>().apply { prop.GetGuidArray(this) }
+                PropertyType.PointArray -> mutableListOf<Point?>().apply { prop.GetPointArray(this) }
+                PropertyType.SizeArray -> mutableListOf<Size?>().apply { prop.GetSizeArray(this) }
+                PropertyType.RectArray -> mutableListOf<Rect?>().apply { prop.GetRectArray(this) }
+                PropertyType.OtherTypeArray -> throw IllegalArgumentException("OtherTypeArray is not supported")
+                null -> throw NullPointerException("PropertyType is null")
+            }
+        }
+        return it
+    }
+
+    override val layout: MemoryLayout
+        get() = ValueLayout.ADDRESS
+
+    @Suppress("UNCHECKED_CAST")
+    override fun toNative(obj: Any): MemoryAddress {
+        return when (obj) {
+            is Unit -> PropertyValue<Unit>(obj).pointer.toMemoryAddress()
+            is UByte -> PropertyValue<UByte>(obj).pointer.toMemoryAddress()
+            is Short -> PropertyValue<Short>(obj).pointer.toMemoryAddress()
+            is UShort -> PropertyValue<UShort>(obj).pointer.toMemoryAddress()
+            is Int -> PropertyValue<Int>(obj).pointer.toMemoryAddress()
+            is UInt -> PropertyValue<UInt>(obj).pointer.toMemoryAddress()
+            is Long -> PropertyValue<Long>(obj).pointer.toMemoryAddress()
+            is ULong -> PropertyValue<ULong>(obj).pointer.toMemoryAddress()
+            is Float -> PropertyValue<Float>(obj).pointer.toMemoryAddress()
+            is Double -> PropertyValue<Double>(obj).pointer.toMemoryAddress()
+            is Char -> PropertyValue<Char>(obj).pointer.toMemoryAddress()
+            is Boolean -> PropertyValue<Boolean>(obj).pointer.toMemoryAddress()
+            is String -> PropertyValue<String>(obj).pointer.toMemoryAddress()
+            is IInspectable -> obj.iUnknown_Ptr.toMemoryAddress()
+            is DateTime -> PropertyValue<DateTime>(obj).pointer.toMemoryAddress()
+            is TimeSpan -> PropertyValue<TimeSpan>(obj).pointer.toMemoryAddress()
+            is GUID -> PropertyValue<GUID>(obj).pointer.toMemoryAddress()
+            is Point -> PropertyValue<Point>(obj).pointer.toMemoryAddress()
+            is Size -> PropertyValue<Size>(obj).pointer.toMemoryAddress()
+            is Rect -> PropertyValue<Rect>(obj).pointer.toMemoryAddress()
+            is Array<*> -> {
+                when (obj::class.java.componentType.kotlin) {
+                    UByte::class -> PropertyValue<Array<UByte>>(obj as Array<UByte>).pointer.toMemoryAddress()
+                    Short::class -> PropertyValue<Array<Short>>(obj as Array<Short>).pointer.toMemoryAddress()
+                    UShort::class -> PropertyValue<Array<UShort>>(obj as Array<UShort>).pointer.toMemoryAddress()
+                    Int::class -> PropertyValue<Array<Int>>(obj as Array<Int>).pointer.toMemoryAddress()
+                    UInt::class -> PropertyValue<Array<UInt>>(obj as Array<UInt>).pointer.toMemoryAddress()
+                    Long::class -> PropertyValue<Array<Long>>(obj as Array<Long>).pointer.toMemoryAddress()
+                    ULong::class -> PropertyValue<Array<ULong>>(obj as Array<ULong>).pointer.toMemoryAddress()
+                    Float::class -> PropertyValue<Array<Float>>(obj as Array<Float>).pointer.toMemoryAddress()
+                    Double::class -> PropertyValue<Array<Double>>(obj as Array<Double>).pointer.toMemoryAddress()
+                    Char::class -> PropertyValue<Array<Char>>(obj as Array<Char>).pointer.toMemoryAddress()
+                    Boolean::class -> PropertyValue<Array<Boolean>>(obj as Array<Boolean>).pointer.toMemoryAddress()
+                    String::class -> PropertyValue<Array<String>>(obj as Array<String>).pointer.toMemoryAddress()
+                    IInspectable::class -> PropertyValue<Array<IInspectable>>(obj as Array<IInspectable>).pointer.toMemoryAddress()
+                    DateTime::class -> PropertyValue<Array<DateTime>>(obj as Array<DateTime>).pointer.toMemoryAddress()
+                    TimeSpan::class -> PropertyValue<Array<TimeSpan>>(obj as Array<TimeSpan>).pointer.toMemoryAddress()
+                    GUID::class -> PropertyValue<Array<GUID>>(obj as Array<GUID>).pointer.toMemoryAddress()
+                    Point::class -> PropertyValue<Array<Point>>(obj as Array<Point>).pointer.toMemoryAddress()
+                    Size::class -> PropertyValue<Array<Size>>(obj as Array<Size>).pointer.toMemoryAddress()
+                    Rect::class -> PropertyValue<Array<Rect>>(obj as Array<Rect>).pointer.toMemoryAddress()
+                    else -> throw IllegalArgumentException("Unsupported array type")
+                }
+            }
+            else -> throw IllegalArgumentException("Unsupported type")
+        }
+    }
+
+}

--- a/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/AnyABI.kt
+++ b/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/AnyABI.kt
@@ -4,13 +4,17 @@ import Windows.Foundation.*
 import com.github.knk190001.winrtbinding.runtime.base.IABI
 import com.github.knk190001.winrtbinding.runtime.com.IInspectable
 import com.github.knk190001.winrtbinding.runtime.com.IUnknown
+import com.sun.jna.Pointer
 import com.sun.jna.platform.win32.Guid.GUID
 import java.lang.foreign.MemoryAddress
 import java.lang.foreign.MemoryLayout
 import java.lang.foreign.ValueLayout
 
-object AnyABI: IABI<Any, MemoryAddress> {
-    override fun fromNative(obj: MemoryAddress): Any {
+object AnyABI: IABI<Any?, MemoryAddress> {
+    override fun fromNative(obj: MemoryAddress): Any? {
+        if (obj == MemoryAddress.NULL) {
+            return null
+        }
         val it = IUnknown.ABI.makeIUnknown(obj.toPointer())
         if (it.instanceOf<IPropertyValue>()) {
             val prop = it.cast<IPropertyValue>()
@@ -66,7 +70,7 @@ object AnyABI: IABI<Any, MemoryAddress> {
         get() = ValueLayout.ADDRESS
 
     @Suppress("UNCHECKED_CAST")
-    override fun toNative(obj: Any): MemoryAddress {
+    override fun toNative(obj: Any?): MemoryAddress {
         return when (obj) {
             is Unit -> PropertyValue<Unit>(obj).pointer.toMemoryAddress()
             is UByte -> PropertyValue<UByte>(obj).pointer.toMemoryAddress()

--- a/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/PropertyValue.kt
+++ b/winrt/src/main/kotlin/com/github/knk190001/winrtbinding/runtime/PropertyValue.kt
@@ -1,10 +1,9 @@
-package com.github.knk190001.winrtbinding.foundation.collections
+package com.github.knk190001.winrtbinding.runtime
 
 import Windows.Foundation.*
 import com.github.knk190001.winrtbinding.runtime.annotations.ObjectImplements
 import com.github.knk190001.winrtbinding.runtime.base.Delegate
 import com.github.knk190001.winrtbinding.runtime.base.KotlinWinRTObject
-import com.github.knk190001.winrtbinding.runtime.com.IUnknown
 import com.sun.jna.platform.win32.Guid
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
@@ -14,24 +13,26 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
+val propertyReferences = mutableListOf<PropertyValue<*>>()
 
 @Suppress("UNCHECKED_CAST")
-@ObjectImplements([IReference::class, IPropertyValue::class])
-class Reference<T>(override val _Windows_FoundationIReference_Type: KType? = null, override val Value: T) :
-    KotlinWinRTObject(), IReference<T> {
+@ObjectImplements([IPropertyValue::class])
+class PropertyValue<T>(val type: KType?, val value: T) :
+    KotlinWinRTObject(), IPropertyValue{
 
     @Suppress("UNCHECKED_CAST")
     constructor() : this(null, null as T)
 
     init {
-        if (_Windows_FoundationIReference_Type != null) {
+        if (type != null) {
             initObj()
         }
+        propertyReferences += this
     }
 
     companion object {
-        inline operator fun <reified T> invoke(value: T): Reference<T> {
-            return Reference(
+        inline operator fun <reified T> invoke(value: T): PropertyValue<T> {
+            return PropertyValue(
                 IReference::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, typeOf<T>()))),
                 value
             )
@@ -70,7 +71,7 @@ class Reference<T>(override val _Windows_FoundationIReference_Type: KType? = nul
     }
 
     override val Type: PropertyType
-        get() = propertyTypeOf(_Windows_FoundationIReference_Type!!.arguments[0].type!!)
+        get() = propertyTypeOf(type!!.arguments[0].type!!)
 
     override val IsNumericScalar: Boolean
         get() = when (Type) {
@@ -79,189 +80,189 @@ class Reference<T>(override val _Windows_FoundationIReference_Type: KType? = nul
             else -> false
         }
 
-    override fun GetUInt8(): Byte {
+    override fun GetUInt8(): UByte {
         if (Type != PropertyType.UInt8) throw IllegalStateException()
-        return Value as Byte
+        return value as UByte
     }
 
 
     override fun GetInt16(): Short {
         if (Type != PropertyType.Int16) throw IllegalStateException()
-        return Value as Short
+        return value as Short
     }
 
     override fun GetUInt16(): UShort {
         if (Type != PropertyType.UInt16) throw IllegalStateException()
-        return Value as UShort
+        return value as UShort
     }
 
     override fun GetInt32(): Int {
         if (Type != PropertyType.Int32) throw IllegalStateException()
-        return Value as Int
+        return value as Int
     }
 
     override fun GetUInt32(): UInt {
         if (Type != PropertyType.UInt32) throw IllegalStateException()
-        return Value as UInt
+        return value as UInt
     }
 
     override fun GetInt64(): Long {
         if (Type != PropertyType.Int64) throw IllegalStateException()
-        return Value as Long
+        return value as Long
     }
 
     override fun GetUInt64(): ULong {
         if (Type != PropertyType.UInt64) throw IllegalStateException()
-        return Value as ULong
+        return value as ULong
     }
 
     override fun GetSingle(): Float {
         if (Type != PropertyType.Single) throw IllegalStateException()
-        return Value as Float
+        return value as Float
     }
 
     override fun GetDouble(): Double {
         if (Type != PropertyType.Double) throw IllegalStateException()
-        return Value as Double
+        return value as Double
     }
 
     override fun GetChar16(): Char {
         if (Type != PropertyType.Char16) throw IllegalStateException()
-        return Value as Char
+        return value as Char
     }
 
     override fun GetBoolean(): Boolean {
         if (Type != PropertyType.Boolean) throw IllegalStateException()
-        return Value as Boolean
+        return value as Boolean
     }
 
     override fun GetString(): String {
         if (Type != PropertyType.String) throw IllegalStateException()
-        return Value as String
+        return value as String
     }
 
     override fun GetGuid(): Guid.GUID {
         if (Type != PropertyType.Guid) throw IllegalStateException()
-        return Value as Guid.GUID
+        return value as Guid.GUID
     }
 
     override fun GetDateTime(): DateTime {
         if (Type != PropertyType.DateTime) throw IllegalStateException()
-        return Value as DateTime
+        return value as DateTime
     }
 
     override fun GetTimeSpan(): TimeSpan {
         if (Type != PropertyType.TimeSpan) throw IllegalStateException()
-        return Value as TimeSpan
+        return value as TimeSpan
     }
 
     override fun GetPoint(): Point {
         if (Type != PropertyType.Point) throw IllegalStateException()
-        return Value as Point
+        return value as Point
     }
 
     override fun GetSize(): Size {
         if (Type != PropertyType.Size) throw IllegalStateException()
-        return Value as Size
+        return value as Size
     }
 
     override fun GetRect(): Rect {
         if (Type != PropertyType.Rect) throw IllegalStateException()
-        return Value as Rect
+        return value as Rect
     }
 
-    override fun GetUInt8Array(value: MutableList<Byte>) {
+    override fun GetUInt8Array(value: MutableList<UByte>) {
         if (Type != PropertyType.UInt8Array) throw IllegalStateException()
-        value.addAll(Value as List<Byte>)
+        value.addAll(value as List<UByte>)
     }
 
     override fun GetInt16Array(value: MutableList<Short>) {
 if (Type != PropertyType.Int16Array) throw IllegalStateException()
-        value.addAll(Value as List<Short>)
+        value.addAll(value as List<Short>)
     }
 
     override fun GetUInt16Array(value: MutableList<UShort>) {
         if (Type != PropertyType.UInt16Array) throw IllegalStateException()
-        value.addAll(Value as List<UShort>)
+        value.addAll(value as List<UShort>)
     }
 
     override fun GetInt32Array(value: MutableList<Int>) {
         if (Type != PropertyType.Int32Array) throw IllegalStateException()
-        value.addAll(Value as List<Int>)
+        value.addAll(value as List<Int>)
     }
 
     override fun GetUInt32Array(value: MutableList<UInt>) {
         if (Type != PropertyType.UInt32Array) throw IllegalStateException()
-        value.addAll(Value as List<UInt>)
+        value.addAll(value as List<UInt>)
     }
 
     override fun GetInt64Array(value: MutableList<Long>) {
         if (Type != PropertyType.Int64Array) throw IllegalStateException()
-        value.addAll(Value as List<Long>)
+        value.addAll(value as List<Long>)
     }
 
     override fun GetUInt64Array(value: MutableList<ULong>) {
         if (Type != PropertyType.UInt64Array) throw IllegalStateException()
-        value.addAll(Value as List<ULong>)
+        value.addAll(value as List<ULong>)
     }
 
     override fun GetSingleArray(value: MutableList<Float>) {
         if (Type != PropertyType.SingleArray) throw IllegalStateException()
-        value.addAll(Value as List<Float>)
+        value.addAll(value as List<Float>)
     }
 
     override fun GetDoubleArray(value: MutableList<Double>) {
         if (Type != PropertyType.DoubleArray) throw IllegalStateException()
-        value.addAll(Value as List<Double>)
+        value.addAll(value as List<Double>)
     }
 
     override fun GetChar16Array(value: MutableList<Char>) {
         if (Type != PropertyType.Char16Array) throw IllegalStateException()
-        value.addAll(Value as List<Char>)
+        value.addAll(value as List<Char>)
     }
 
     override fun GetBooleanArray(value: MutableList<Boolean>) {
         if (Type != PropertyType.BooleanArray) throw IllegalStateException()
-        value.addAll(Value as List<Boolean>)
+        value.addAll(value as List<Boolean>)
     }
 
     override fun GetStringArray(value: MutableList<String?>) {
         if (Type != PropertyType.StringArray) throw IllegalStateException()
-        value.addAll(Value as List<String?>)
+        value.addAll(value as List<String?>)
     }
 
-    override fun GetInspectableArray(value: MutableList<IUnknown?>) {
+    override fun GetInspectableArray(value: MutableList<Any?>) {
         if (Type != PropertyType.InspectableArray) throw IllegalStateException()
-        value.addAll(Value as List<IUnknown?>)
+        value.addAll(value as List<Any?>)
     }
 
     override fun GetGuidArray(value: MutableList<Guid.GUID?>) {
         if (Type != PropertyType.GuidArray) throw IllegalStateException()
-        value.addAll(Value as List<Guid.GUID?>)
+        value.addAll(value as List<Guid.GUID?>)
     }
 
     override fun GetDateTimeArray(value: MutableList<DateTime?>) {
         if (Type != PropertyType.DateTimeArray) throw IllegalStateException()
-        value.addAll(Value as List<DateTime?>)
+        value.addAll(value as List<DateTime?>)
     }
 
     override fun GetTimeSpanArray(value: MutableList<TimeSpan?>) {
         if (Type != PropertyType.TimeSpanArray) throw IllegalStateException()
-        value.addAll(Value as List<TimeSpan?>)
+        value.addAll(value as List<TimeSpan?>)
     }
 
     override fun GetPointArray(value: MutableList<Point?>) {
         if (Type != PropertyType.PointArray) throw IllegalStateException()
-        value.addAll(Value as List<Point?>)
+        value.addAll(value as List<Point?>)
     }
 
     override fun GetSizeArray(value: MutableList<Size?>) {
         if (Type != PropertyType.SizeArray) throw IllegalStateException()
-        value.addAll(Value as List<Size?>)
+        value.addAll(value as List<Size?>)
     }
 
     override fun GetRectArray(value: MutableList<Rect?>) {
         if (Type != PropertyType.RectArray) throw IllegalStateException()
-        value.addAll(Value as List<Rect?>)
+        value.addAll(value as List<Rect?>)
     }
 }


### PR DESCRIPTION
Changes:
* Added sources to maven artifacts
* Added IInspectable and made all interfaces derive from it instead of IUnknown
* Changed the System.Object projection from IUnknown to IInspectable
* Fixed a few instances where JNA unsigned types were being used
* Fixed an issue where KTypes with type arguments weren't being reified
* Added helper functions that allow check if an IUnknown implements an interface and cast to it directly without needing to manually instantiate the corresponding impl type
* Fixed an issue where vtables for types that implement IKotlinWinRTAggregate would be prematurely gc'd
* Added IAgileObject to the list of interfaces implemented by delegates 
* Changed IUnknown .QueryInterface to return IUnknown instead of the pointer to it
* Fixed a bug where the pointer offsets into the IUnknown vtable weren't being multiplied by the pointer size leading to a crash